### PR TITLE
Show glimmer devices under 'Connected Devices' in Fadecandy Server http UI

### DIFF
--- a/server/http/js/home.js
+++ b/server/http/js/home.js
@@ -76,7 +76,7 @@ jQuery(function ($) {
         '));
 
         // Other initialization is device-type-specific
-        if (json.type == "fadecandy") {
+        if (json.type == "fadecandy" || json.type == "glimmer") {
             this.initTypeFadecandy();
         } else if (json.type == "apa102spi") {
             this.initTypeAPA102SPI();


### PR DESCRIPTION
Simple fix for the UI to enable testing functionality for glimmer devices.